### PR TITLE
make default delimiter value a newline (fixes #8)

### DIFF
--- a/src/Net.Sf.Dbdeploy/Configuration/DbDeployDefaults.cs
+++ b/src/Net.Sf.Dbdeploy/Configuration/DbDeployDefaults.cs
@@ -48,7 +48,7 @@
         /// <summary>
         /// The delimiter default value.
         /// </summary>
-        public const string Delimiter = null;
+        public const string Delimiter = "\n";
 
         /// <summary>
         /// The output file default value.


### PR DESCRIPTION
Make default delimiter value a newline to prevent null-exceptions with the default configuration.